### PR TITLE
Add uninstall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,11 @@
 *.pyo
 *.mo
 dist
+.installed.cfg
+bin/
+develop-eggs/
+include/
+lib/
+parts/
+share/
+

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.4 (unreleased)
 ----------------
 
+- Add extenisons folder for uninstallation.
+  [bsuttor]
+
 - Fix tests
   [jaroel]
 

--- a/src/collective/alias/Extensions/install.py
+++ b/src/collective/alias/Extensions/install.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from Products.CMFCore import utils as cmfutils
+from zope import interface
+from zope.component.interface import interfaceToName
+from collective.alias.interfaces import IHasAlias
+import logging
+logger = logging.getLogger("collective.alias uninstall")
+
+
+def uninstall(portal, reinstall=False):
+    if not reinstall:
+
+        # Unprovide all objects from collective.alias.interfaces.IHasAlias
+        obj_unprovided = remove_marker_ifaces(portal, IHasAlias)
+        logger.info("{0} object unregistred from IHasAlias interface.".format(obj_unprovided))
+        # setup_tool = portal.portal_setup
+        # setup_tool.runAllImportStepsFromProfile('profile-example.gs:uninstall')
+
+
+def objs_with_iface(context, iface):
+    """Return all objects in the system as found by the nearest portal
+    catalog that provides the given interface.  The result will be a generator
+    """
+
+    catalog = cmfutils.getToolByName(context, 'portal_catalog')
+
+    for brain in catalog(object_provides=interfaceToName(context, iface)):
+        obj = brain.getObject()
+        if iface in interface.directlyProvidedBy(obj):
+            yield brain.getObject()
+
+
+def remove_marker_ifaces(context, ifaces):
+    """Remove the given interfaces from all objects using a catalog
+    query.  context needs to either be the portal or be properly aq wrapped
+    to allow for cmf catalog tool lookup.  ifaces can be either a single
+    interface or a sequence of interfaces.
+    """
+
+    if not isinstance(ifaces, (tuple, list)):
+        ifaces = [ifaces]
+
+    count = 0
+    for iface in ifaces:
+        for obj in objs_with_iface(context, iface):
+            count += 1
+            provided = interface.directlyProvidedBy(obj)
+            interface.directlyProvides(obj, provided - iface)
+    return count

--- a/src/collective/alias/configure.zcml
+++ b/src/collective/alias/configure.zcml
@@ -7,6 +7,8 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     i18n_domain="collective.alias">
 
+  <five:registerPackage package="." />
+
   <i18n:registerTranslations directory="locales" />
 
   <includeDependencies package="." />

--- a/src/collective/alias/tests/test_aliasing.py
+++ b/src/collective/alias/tests/test_aliasing.py
@@ -36,96 +36,96 @@ def object_event_handler(obj, event):
     events_received.append((obj, event))
 
 class ITest(Interface):
-    
+
     title = schema.TextLine(title=u"Title")
     foo = schema.Text(title=u"Foo")
 
 class TestAliasing(PloneTestCase):
-    
+
     layer = Layer
-    
+
     def afterSetUp(self):
         global events_received
         events_received = []
-        
+
         newInteraction() # workaround for problem with checkPermission
 
         self.intids = getUtility(IIntIds)
-        
+
         self.folder.invokeFactory('Document', 'd1')
         self.folder['d1'].setTitle("Document one")
         self.folder['d1'].setDescription("Document one description")
         self.folder['d1'].setText("<p>Document one body</p>")
-        
+
         relation = RelationValue(self.intids.getId(self.folder['d1']))
         self.folder.invokeFactory('collective.alias', 'a1', _aliasTarget=relation)
-    
+
     def test_alias_archetypes_object(self):
         self.failUnless(self.folder['a1'].isAlias)
-        
+
         self.assertEquals("Document one", self.folder['a1'].Title())
         self.assertEquals("Document one", self.folder['a1'].title)
-        
+
         self.assertEquals("Document one description", self.folder['a1'].Description())
         self.assertEquals("<p>Document one body</p>", self.folder['a1'].getText())
-    
+
     def test_alias_dexterity_object(self):
         tt = getToolByName(self.portal, 'portal_types')
-        
+
         fti = DexterityFTI('collective.alias.test')
         fti.schema = ITest.__identifier__
-        
+
         tt._setObject('collective.alias.test', fti)
-        
+
         self.folder.invokeFactory('collective.alias.test', 't1')
         self.folder['t1'].title = "Dummy title"
         self.folder['t1'].foo = "Foo Bar"
-        
+
         relation = RelationValue(self.intids.getId(self.folder['t1']))
         self.folder.invokeFactory('collective.alias', 'a2', _aliasTarget=relation)
-        
+
         self.failUnless(ITest.providedBy(self.folder['a2']))
         self.assertEquals("Dummy title", self.folder['a2'].title)
         self.assertEquals("Foo Bar", self.folder['a2'].foo)
-    
+
     def test_portal_type(self):
         self.assertEquals('Document', self.folder['a1'].portal_type)
-    
+
     def test_alias_interfaces(self):
         self.failUnless(IATDocument.providedBy(self.folder['a1']))
         self.failUnless(IAlias.providedBy(self.folder['a1']))
         self.failIf(IAlias.providedBy(self.folder['d1']))
-    
+
     def test_has_alias(self):
         self.folder.invokeFactory('Document', 'd2')
         self.failIf(IHasAlias.providedBy(self.folder['d2']))
         self.failUnless(IHasAlias.providedBy(self.folder['d1']))
-    
+
     def test_has_alias_removed_on_delete(self):
         self.failUnless(IHasAlias.providedBy(self.folder['d1']))
         self.folder._delObject('a1')
         self.failIf(IHasAlias.providedBy(self.folder['d1']))
-    
+
     def test_has_alias_counter_up(self):
         relation = RelationValue(self.intids.getId(self.folder['d1']))
         self.folder.invokeFactory('collective.alias', 'a2', _aliasTarget=relation)
-        
+
         self.failUnless(IHasAlias.providedBy(self.folder['d1']))
         self.folder._delObject('a1')
         self.failUnless(IHasAlias.providedBy(self.folder['d1']))
         self.folder._delObject('a2')
         self.failIf(IHasAlias.providedBy(self.folder['d1']))
-    
+
     def test_has_alias_counter_down(self):
         relation = RelationValue(self.intids.getId(self.folder['d1']))
         self.folder.invokeFactory('collective.alias', 'a2', _aliasTarget=relation)
-        
+
         self.failUnless(IHasAlias.providedBy(self.folder['d1']))
         self.folder._delObject('a2')
         self.failUnless(IHasAlias.providedBy(self.folder['d1']))
         self.folder._delObject('a1')
         self.failIf(IHasAlias.providedBy(self.folder['d1']))
-    
+
     def test_has_alias_clone_loses_marker(self):
         self.failUnless(IHasAlias.providedBy(self.folder['d1']))
         cp = self.folder.manage_copyObjects('d1')
@@ -134,7 +134,7 @@ class TestAliasing(PloneTestCase):
         newId = result[0]['new_id']
         self.failUnless(IHasAlias.providedBy(self.folder['d1']))
         self.failIf(IHasAlias.providedBy(self.folder[newId]))
-    
+
     def test_transitive_alias(self):
         relation = RelationValue(self.intids.getId(self.folder['a1']))
         self.folder.invokeFactory('collective.alias', 'a2', _aliasTarget=relation)
@@ -145,142 +145,142 @@ class TestAliasing(PloneTestCase):
         self.folder.invokeFactory('collective.alias', 'a2', _aliasTarget=relation, _aliasTitle=u"Title override")
         self.assertEquals("Title override", self.folder['a2'].Title())
         self.assertEquals("Title override", self.folder['a2'].title)
-        
+
         self.assertEquals("Document one description", self.folder['a2'].Description())
         self.assertEquals("<p>Document one body</p>", self.folder['a2'].getText())
-        
+
     def test_folderishness(self):
         self.failIf(self.folder['a1'].isPrincipiaFolderish)
-        
+
         self.folder.invokeFactory('Folder', 'f1')
         relation = RelationValue(self.intids.getId(self.folder['f1']))
         self.folder.invokeFactory('collective.alias', 'a2', _aliasTarget=relation)
         self.failUnless(self.folder['a2'].isPrincipiaFolderish)
-    
+
     def test_alias_traversal(self):
         self.folder.invokeFactory('Folder', 'f1')
         relation = RelationValue(self.intids.getId(self.folder['f1']))
-        
+
         self.folder['f1'].invokeFactory('Document', 'd11')
-        
+
         self.folder.invokeFactory('collective.alias', 'a2', _aliasTarget=relation)
         self.assertRaises(KeyError, self.folder['a1'].__getitem__, 'd11')
-        
+
         self.folder['a2']._aliasTraversal = True
         self.failUnless(self.folder['a2']['d11'].aq_base, self.folder['f1']['d11'].aq_base)
-        
+
     def test_alias_child(self):
         self.folder.invokeFactory('Folder', 'f1')
-        
+
         relation = RelationValue(self.intids.getId(self.folder['f1']))
         self.folder.invokeFactory('collective.alias', 'a2', _aliasTarget=relation)
-        
+
         self.folder['a2'].invokeFactory('Document', 'd21')
         self.assertEquals(self.folder['a2'].absolute_url() + '/d21',
                           self.folder['a2']['d21'].absolute_url())
-    
+
     def test_permissions_not_aliased(self):
         self.failUnless(checkPermission('zope2.View', self.folder['d1']))
         self.folder['d1'].manage_permission('View', roles=['Manager'])
         self.failIf(checkPermission('zope2.View', self.folder['d1']))
         self.failUnless(checkPermission('zope2.View', self.folder['a1']))
-    
+
     def test_workflow_not_aliased_change_target(self):
         self.setRoles(['Manager'])
         wf = getToolByName(self.portal, 'portal_workflow')
-        
+
         self.assertEquals('private', wf.getInfoFor(self.folder['d1'], 'review_state'))
         self.assertEquals('private', wf.getInfoFor(self.folder['a1'], 'review_state'))
-        
+
         wf.doActionFor(self.folder['d1'], 'publish')
-        
+
         self.assertEquals('published', wf.getInfoFor(self.folder['d1'], 'review_state'))
         self.assertEquals('private', wf.getInfoFor(self.folder['a1'], 'review_state'))
-    
+
     def test_workflow_not_aliased_change_alias(self):
         self.setRoles(['Manager'])
         wf = getToolByName(self.portal, 'portal_workflow')
-        
+
         self.assertEquals('private', wf.getInfoFor(self.folder['d1'], 'review_state'))
         self.assertEquals('private', wf.getInfoFor(self.folder['a1'], 'review_state'))
-        
+
         wf.doActionFor(self.folder['a1'], 'publish')
-        
+
         self.assertEquals('private', wf.getInfoFor(self.folder['d1'], 'review_state'))
         self.assertEquals('published', wf.getInfoFor(self.folder['a1'], 'review_state'))
-    
+
     def test_workflow_chain_aliased(self):
         wf = getToolByName(self.portal, 'portal_workflow')
         wf.setChainForPortalTypes(('collective.alias',), ())
-        
+
         relation = RelationValue(self.intids.getId(self.folder['d1']))
         self.folder.invokeFactory('collective.alias', 'a2', _aliasTarget=relation)
-        
+
         self.assertEquals(('simple_publication_workflow',), wf.getChainFor(self.folder['a2']))
-    
+
     def test_workflow_initial_state(self):
         wf = getToolByName(self.portal, 'portal_workflow')
-        
+
         self.assertEquals(('simple_publication_workflow',), wf.getChainFor(self.folder['d1']))
         wf['simple_publication_workflow'].initial_state = 'published'
-        
+
         relation = RelationValue(self.intids.getId(self.folder['d1']))
         self.folder.invokeFactory('collective.alias', 'a2', _aliasTarget=relation)
-        
+
         self.assertEquals('private', wf.getInfoFor(self.folder['a1'], 'review_state'))
         self.assertEquals('private', wf.getInfoFor(self.folder['d1'], 'review_state'))
         self.assertEquals('published', wf.getInfoFor(self.folder['a2'], 'review_state'))
-    
+
     def test_display_templates(self):
         self.folder.invokeFactory('Folder', 'f1')
-        
+
         relation = RelationValue(self.intids.getId(self.folder['f1']))
         self.folder.invokeFactory('collective.alias', 'a2', _aliasTarget=relation)
-        
+
         self.folder['f1'].setLayout('folder_tabular_view')
         self.assertEquals('folder_tabular_view', self.folder['f1'].getLayout())
         self.assertEquals('folder_tabular_view', self.folder['a2'].getLayout())
-        
+
         self.folder['a2'].setLayout('folder_listing')
         self.assertEquals('folder_tabular_view', self.folder['f1'].getLayout())
         self.assertEquals('folder_listing', self.folder['a2'].getLayout())
-    
+
     def test_annotations(self):
         d1 = IAnnotations(self.folder['d1'])
         a1 = IAnnotations(self.folder['a1'])
-        
+
         d1['test.key1'] = 1
         self.assertEquals(1, a1['test.key1'])
-        
+
         a1['test.key2'] = 2
         self.assertEquals(2, a1['test.key2'])
         self.failIf('test.key2' in d1)
-        
+
         a1['test.key1'] = 3
         self.assertEquals(1, d1['test.key1'])
         self.assertEquals(3, a1['test.key1'])
-    
+
     def test_modified_event_rebroadcast(self):
         provideHandler(object_event_handler, (IAlias, IObjectModifiedEvent,))
-        
+
         modified(self.folder['d1'])
-        
+
         self.assertEquals(1, len(events_received))
         self.failUnless(self.folder['a1'].aq_base is events_received[0][0].aq_base)
-        
+
         sm = getGlobalSiteManager()
         sm.unregisterHandler(object_event_handler, required=(IAlias, IObjectModifiedEvent,))
-    
+
     def test_comments(self):
         pd = getToolByName(self.portal, 'portal_discussion')
-        
+
         self.folder['d1'].getTypeInfo().allow_discussion = True
-        
+
         discussion = pd.getDiscussionFor(self.folder['d1'])
         discussion.createReply("Reply 1", "Some text")
-        
+
         discussion = pd.getDiscussionFor(self.folder['a1'])
-        
+
         self.assertEquals(1, discussion.replyCount(self.folder['a1']))
         self.assertEquals("Reply 1", discussion.getReplies()[0].title)
 

--- a/src/collective/alias/tests/test_info.py
+++ b/src/collective/alias/tests/test_info.py
@@ -1,3 +1,4 @@
+
 import unittest
 
 from Products.PloneTestCase.ptc import PloneTestCase
@@ -13,86 +14,86 @@ from collective.alias.interfaces import IAliasInformation
 from collective.alias.interfaces import IHasAlias
 
 class TestAliasing(PloneTestCase):
-    
+
     layer = Layer
-    
+
     def afterSetUp(self):
         self.intids = getUtility(IIntIds)
-        
+
         self.folder.invokeFactory('Document', 'd1')
         self.folder['d1'].setTitle("Document one")
         self.folder['d1'].setDescription("Document one description")
         self.folder['d1'].setText("<p>Document one body</p>")
-    
+
     def test_lookup_no_alias(self):
         info = IAliasInformation(self.folder['d1'], None)
         self.assertEquals(None, info)
-        
+
     def test_find_aliases_single(self):
         relation = RelationValue(self.intids.getId(self.folder['d1']))
         self.folder.invokeFactory('collective.alias', 'a1', _aliasTarget=relation)
-        
+
         info = IAliasInformation(self.folder['d1'])
-        
+
         aliases = list(info.findAliases())
         self.assertEquals(1, len(aliases))
         self.failUnless(aliases[0].aq_parent.aq_base is self.folder.aq_base)
         self.assertEquals(self.folder['a1'].getPhysicalPath(), aliases[0].getPhysicalPath())
-    
+
     def test_find_aliases_multiple(self):
         relation = RelationValue(self.intids.getId(self.folder['d1']))
         self.folder.invokeFactory('collective.alias', 'a1', _aliasTarget=relation)
-        
+
         relation = RelationValue(self.intids.getId(self.folder['d1']))
         self.folder.invokeFactory('collective.alias', 'a2', _aliasTarget=relation)
-        
+
         info = IAliasInformation(self.folder['d1'])
-        
+
         aliases = list(info.findAliases())
         self.assertEquals(2, len(aliases))
-        
+
         self.failUnless(aliases[0].aq_parent.aq_base is self.folder.aq_base)
         self.assertEquals(self.folder['a1'].getPhysicalPath(), aliases[0].getPhysicalPath())
-        
+
         self.failUnless(aliases[1].aq_parent.aq_base is self.folder.aq_base)
         self.assertEquals(self.folder['a2'].getPhysicalPath(), aliases[1].getPhysicalPath())
-        
+
     def test_find_aliases_none(self):
         # dodgy IHasAlias marker
         alsoProvides(self.folder['d1'], IHasAlias)
-        
+
         info = IAliasInformation(self.folder['d1'])
         aliases = list(info.findAliases())
         self.assertEquals(0, len(aliases))
-    
+
     def test_find_ids_single(self):
         relation = RelationValue(self.intids.getId(self.folder['d1']))
         self.folder.invokeFactory('collective.alias', 'a1', _aliasTarget=relation)
-        
+
         info = IAliasInformation(self.folder['d1'])
-        
+
         aliases = list(info.findAliasIds())
         self.assertEquals(1, len(aliases))
         self.assertEquals(self.intids.getId(self.folder['a1']), aliases[0])
-    
+
     def test_find_ids_multiple(self):
         relation = RelationValue(self.intids.getId(self.folder['d1']))
         self.folder.invokeFactory('collective.alias', 'a1', _aliasTarget=relation)
-        
+
         relation = RelationValue(self.intids.getId(self.folder['d1']))
         self.folder.invokeFactory('collective.alias', 'a2', _aliasTarget=relation)
-        
+
         info = IAliasInformation(self.folder['d1'])
-        
+
         aliases = list(info.findAliasIds())
         self.assertEquals(2, len(aliases))
         self.assertEquals(self.intids.getId(self.folder['a1']), aliases[0])
         self.assertEquals(self.intids.getId(self.folder['a2']), aliases[1])
-        
+
     def test_find_ids_none(self):
         # dodgy IHasAlias marker
         alsoProvides(self.folder['d1'], IHasAlias)
-        
+
         info = IAliasInformation(self.folder['d1'])
         aliases = list(info.findAliasIds())
         self.assertEquals(0, len(aliases))

--- a/src/collective/alias/tests/test_paste.py
+++ b/src/collective/alias/tests/test_paste.py
@@ -11,77 +11,77 @@ from collective.alias.interfaces import IAliasSettings
 from collective.alias.paste import pasteAsAlias
 
 class TestSetup(PloneTestCase):
-    
+
     layer = Layer
-    
+
     def test_paste_single(self):
         self.folder.invokeFactory('Folder', 'source')
         self.folder.invokeFactory('Folder', 'dest')
-        
+
         self.folder['source'].invokeFactory('Document', 'd1')
-        
+
         data = self.folder['source'].manage_copyObjects(('d1',))
         pasteAsAlias(self.folder['dest'], data)
-        
+
         alias = self.folder['dest']['d1']
         self.failUnless(alias.isAlias)
-        
+
         self.failUnless(alias._target.aq_base is self.folder['source']['d1'].aq_base)
-    
+
     def test_paste_multiple(self):
         self.folder.invokeFactory('Folder', 'source')
         self.folder.invokeFactory('Folder', 'dest')
-        
+
         self.folder['source'].invokeFactory('Document', 'd1')
         self.folder['source'].invokeFactory('Document', 'd2')
-        
+
         data = self.folder['source'].manage_copyObjects(('d1', 'd2',))
         pasteAsAlias(self.folder['dest'], data)
-        
+
         alias1 = self.folder['dest']['d1']
         self.failUnless(alias1.isAlias)
         self.failUnless(alias1._target.aq_base is self.folder['source']['d1'].aq_base)
-        
+
         alias2 = self.folder['dest']['d2']
         self.failUnless(alias2.isAlias)
         self.failUnless(alias2._target.aq_base is self.folder['source']['d2'].aq_base)
-        
+
     def test_paste_same_directory(self):
         self.folder.invokeFactory('Folder', 'source')
-        
+
         self.folder['source'].invokeFactory('Document', 'd1')
-        
+
         data = self.folder['source'].manage_copyObjects(('d1',))
         pasteAsAlias(self.folder['source'], data)
-        
+
         alias = self.folder['source']['d1-1']
         self.failUnless(alias.isAlias)
-        
+
         self.failUnless(alias._target.aq_base is self.folder['source']['d1'].aq_base)
-    
+
     def test_paste_traversal(self):
-        
+
         settings = getUtility(IRegistry).forInterface(IAliasSettings)
         settings.traversalTypes = ['Folder']
-        
+
         self.folder.invokeFactory('Folder', 'source')
         self.folder.invokeFactory('Folder', 'dest')
-        
+
         self.folder['source'].invokeFactory('Document', 'd1')
         self.folder['source'].invokeFactory('Folder', 'f1')
-        
+
         data = self.folder['source'].manage_copyObjects(('d1', 'f1',))
         pasteAsAlias(self.folder['dest'], data)
-        
+
         alias1 = self.folder['dest']['d1']
         self.failUnless(alias1.isAlias)
         self.failUnless(alias1._target.aq_base is self.folder['source']['d1'].aq_base)
         self.assertEquals(False, alias1._aliasTraversal)
-        
+
         alias2 = self.folder['dest']['f1']
         self.failUnless(alias2.isAlias)
         self.failUnless(alias2._target.aq_base is self.folder['source']['f1'].aq_base)
         self.assertEquals(True, alias2._aliasTraversal)
-    
+
 def test_suite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/src/collective/alias/tests/test_setup.py
+++ b/src/collective/alias/tests/test_setup.py
@@ -4,9 +4,14 @@ from Products.PloneTestCase.ptc import PloneTestCase
 from collective.alias.tests.layer import Layer
 
 from zope.component import getUtility
+from zope.component.interface import interfaceToName
+from zope import interface
 from Products.CMFCore.utils import getToolByName
 from plone.registry.interfaces import IRegistry
 from collective.alias.interfaces import IAliasSettings
+from collective.alias.interfaces import IHasAlias
+from z3c.relationfield import RelationValue
+from zope.intid.interfaces import IIntIds
 
 
 class TestSetup(PloneTestCase):
@@ -26,6 +31,27 @@ class TestSetup(PloneTestCase):
         records = reg.forInterface(IAliasSettings)
         self.failUnless('Collection' in records.traversalTypes)
         self.failUnless('view' in records.aliasActions)
+
+    def test_uninstall(self):
+        pid = 'collective.alias'
+        self.folder.invokeFactory('Document', 'd1')
+        self.folder['d1'].setTitle("Document one")
+        self.folder['d1'].setDescription("Document one description")
+        self.folder['d1'].setText("<p>Document one body</p>")
+
+        intids = getUtility(IIntIds)
+
+        relation = RelationValue(intids.getId(self.folder['d1']))
+        self.folder.invokeFactory('collective.alias', 'a1', _aliasTarget=relation)
+        self.folder["d1"].reindexObject()
+        self.assertTrue(IHasAlias.providedBy(self.folder['d1']))
+
+        qi_tool = getToolByName(self.portal, 'portal_quickinstaller')
+        qi_tool.uninstallProducts([pid])
+        self.assertFalse(qi_tool.isProductInstalled(pid))
+        self.folder["d1"].reindexObject()
+        self.assertFalse(IHasAlias.providedBy(self.folder['d1']))
+
 
 def test_suite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)


### PR DESCRIPTION
When I uninstall `collective.alias` and remove it from buildout, I had an error :

```
TypeError: ("'ExtensionClass.ExtensionClass' object is not iterable", <class 'collective.alias.interfaces.IHasAlias'>))
```

So I added an uninstall method for removing `IHasAlias` interface from object provided by it.
